### PR TITLE
Twig namespacing

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,3 @@
-var path = require('path')
-
 import { configure } from "@storybook/react"
 import { action } from "@storybook/addon-actions"
 
@@ -19,26 +17,10 @@ twigBEM(Twig);
 twigAddAttributes(Twig);
 
  // automatically import all files ending in *.stories.js
-const req = require.context("../components", true, /.stories.js$/)
+const req = require.context('../components', true, /.stories.js$/)
 function loadStories() {
   req.keys().forEach(filename => req(filename))
 }
-
-const context = require.context('../components', true, /\.twig$/)
-context.keys().forEach(key => {
-  var template = context(key);
-  const rootPath = path.join(__dirname);
-  Twig.twig({
-    base: rootPath, // Possibly can set a base directory for everything to work from?
-    namespaces: {
-      'atoms': 'components/01-atoms',
-    },
-    id: key,
-    data: template.tokens,
-    // allowInlineIncludes: true, // This seems to be an alternative to namespacing which allows relative paths.
-    rethrow: true
-  }).render();
-});
 
 // Gatsby's Link overrides:
 // Gatsby defines a global called ___loader to prevent its method calls from creating console errors you override it here

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -29,16 +29,13 @@ context.keys().forEach(key => {
   var template = context(key);
   const rootPath = path.join(__dirname);
   Twig.twig({
-    base: rootPath,
+    base: rootPath, // Possibly can set a base directory for everything to work from?
     namespaces: {
-      // 'base': 'components/00-base',
       'atoms': 'components/01-atoms',
-      // 'molecules': 'components/02-molecules',
-      // 'organisms': 'components/03-organisms',
     },
     id: key,
     data: template.tokens,
-    allowInlineIncludes: true,
+    allowInlineIncludes: true, // This seems to be an alternative to namespacing which allows relative paths.
     rethrow: true
   }).render();
 });

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,3 +1,5 @@
+var path = require('path')
+
 import { configure } from "@storybook/react"
 import { action } from "@storybook/addon-actions"
 
@@ -26,11 +28,17 @@ const context = require.context('../components', true, /\.twig$/)
 context.keys().forEach(key => {
   var template = context(key);
   Twig.twig({
+    namespaces: {
+      'base': 'components/00-base',
+      'atoms': path.join(__dirname, '/components/01-atoms/'),
+      'molecules': 'components/02-molecules',
+      'organisms': 'components/03-organisms',
+    },
     id: key,
     data: template.tokens,
-    allowInlineIncludes: true,
-    rethrow: true
-  });
+    // allowInlineIncludes: true,
+    // rethrow: true
+  }).render();
 });
 
 // Gatsby's Link overrides:

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -35,7 +35,7 @@ context.keys().forEach(key => {
     },
     id: key,
     data: template.tokens,
-    allowInlineIncludes: true, // This seems to be an alternative to namespacing which allows relative paths.
+    // allowInlineIncludes: true, // This seems to be an alternative to namespacing which allows relative paths.
     rethrow: true
   }).render();
 });

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -27,17 +27,19 @@ function loadStories() {
 const context = require.context('../components', true, /\.twig$/)
 context.keys().forEach(key => {
   var template = context(key);
+  const rootPath = path.join(__dirname);
   Twig.twig({
+    base: rootPath,
     namespaces: {
-      'base': 'components/00-base',
-      'atoms': path.join(__dirname, '/components/01-atoms/'),
-      'molecules': 'components/02-molecules',
-      'organisms': 'components/03-organisms',
+      // 'base': 'components/00-base',
+      'atoms': 'components/01-atoms',
+      // 'molecules': 'components/02-molecules',
+      // 'organisms': 'components/03-organisms',
     },
     id: key,
     data: template.tokens,
-    // allowInlineIncludes: true,
-    // rethrow: true
+    allowInlineIncludes: true,
+    rethrow: true
   }).render();
 });
 

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,9 +1,6 @@
-module.exports = async ({ config }) => {
-  // Commented code below makes directory set to `./storybook`.
-  // config.node = {
-  //   __dirname: true
-  // }
+const path = require('path')
 
+module.exports = async ({ config }) => {
   // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
   config.module.rules[0].exclude = [/node_modules\/(?!(gatsby)\/)/]
 
@@ -27,8 +24,22 @@ module.exports = async ({ config }) => {
   config.resolve.mainFields = ["browser", "module", "main"]
 
   // Twig
-  config.module.rules[1].test = [/\.twig$/]
-  config.module.rules[1].use[0].loader = require.resolve("twig-loader")
+  config.module.rules.push({
+    test: /\.twig$/,
+    use: [
+      {
+        loader: 'twig-loader',
+        options: {
+          twigOptions: {
+            namespaces: {
+              atoms: path.resolve(__dirname, '../', 'components/01-atoms'),
+              molecules: path.resolve(__dirname, '../', 'components/02-molecules'),
+            },
+          },
+        },
+      },
+    ],
+  });
 
   return config
 }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,9 @@
 module.exports = async ({ config }) => {
+  // Commented code below makes directory set to `./storybook`.
+  // config.node = {
+  //   __dirname: true
+  // }
+
   // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
   config.module.rules[0].exclude = [/node_modules\/(?!(gatsby)\/)/]
 

--- a/components/02-molecules/cta/cta.twig
+++ b/components/02-molecules/cta/cta.twig
@@ -2,5 +2,5 @@
  <h2>{{ cta__heading }}</h2>
  {% include "@atoms/button/button.twig" with {
    button_content: cta__button_text,
- } %}
+ }%}
 </div>

--- a/components/02-molecules/cta/cta.twig
+++ b/components/02-molecules/cta/cta.twig
@@ -1,6 +1,6 @@
 <div class="cta">
  <h2>{{ cta__heading }}</h2>
- {% include "../../01-atoms/button/button.twig" with {
+ {% include "@atoms/button/button.twig" with {
    button_content: cta__button_text,
- }%}
+ } %}
 </div>

--- a/components/02-molecules/cta/cta.twig
+++ b/components/02-molecules/cta/cta.twig
@@ -2,5 +2,5 @@
  <h2>{{ cta__heading }}</h2>
  {% include "@atoms/button/button.twig" with {
    button_content: cta__button_text,
- }%}
+ } %}
 </div>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^16.8.6",
     "twig": "^1.13.3",
     "twig-drupal-filters": "^2.0.0",
-    "twig-loader": "^0.5.1"
+    "twig-loader": "https://github.com/AmazeeLabs/twig-loader"
   },
   "scripts": {
     "develop-gatsby": "gatsby develop",


### PR DESCRIPTION
Attempt to get [namespacing](https://github.com/twigjs/twig.js/wiki#namespaces) working in the Storybook implementation of Twig.js. 

To work on this PR, install this repo as normal (clone and `yarn`) and then run `yarn develop`

Had to use [this forked twig-loader repo](https://github.com/AmazeeLabs/twig-loader), but it is now working. I'm not crazy about this reality, and have pinged someone at Amazee Labs about it in DrupalTwig Slack. But it is working, so...

To test, just try and edit or add new components that use either the `atoms` or `molecules` namespace.